### PR TITLE
Fix dominant audio muting on widget close

### DIFF
--- a/src/components/AudioTrack/AudioTrack.tsx
+++ b/src/components/AudioTrack/AudioTrack.tsx
@@ -11,10 +11,11 @@ export default function AudioTrack({ track }: AudioTrackProps) {
   useEffect(() => {
     const el = ref.current;
     track.attach(el);
+    el.muted = false;
     return () => {
       track.detach(el);
     };
   }, [track]);
 
-  return <audio ref={ref} />;
+  return <audio ref={ref} muted={false} />;
 }

--- a/src/components/ParticipantTracks/ParticipantTracks.tsx
+++ b/src/components/ParticipantTracks/ParticipantTracks.tsx
@@ -45,7 +45,7 @@ export default function ParticipantTracks({
           publication={publication}
           participant={participant}
           isLocal={isLocal}
-          disableAudio={false}
+          disableAudio={disableAudio}
           videoPriority={videoPriority}
         />
       ))}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,6 @@ import theme from './theme';
 import './types';
 import { VideoProvider } from './components/VideoProvider';
 import UserSetup from './components/UserSetup/UserSetup';
-import WelcomeVideo from './components/WelcomeVideo/WelcomeVideo';
 
 // See: https://media.twiliocdn.com/sdk/js/video/releases/2.0.0/docs/global.html#ConnectOptions
 // for available connection options.


### PR DESCRIPTION
No earthly idea why this happens, but when we close a widget, the dominant speaker's `<audio />` tag gets muted on the DOM object only. I suspect React is doing something weird somewhere, but anyways, it's easy to just work around now that we know where the problem is.

This just ensures the `<audio />` tag for participant tracks is never muted. It should never have to be, because when people mute themselves, they simply don't send audio data.