### PR TITLE
Show room drawer by default & hide room description if not present

### DIFF
--- a/src/components/LocalVideoPreview/LocalVideoPreview.tsx
+++ b/src/components/LocalVideoPreview/LocalVideoPreview.tsx
@@ -10,7 +10,6 @@ const Container = styled('div')({
   margin: 'auto',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
   flexDirection: 'column',
 });
 
@@ -24,10 +23,10 @@ export default function LocalVideoPreview() {
 
   const videoTrack = localTracks.find(track => track.name === 'camera') as LocalVideoTrack;
 
-  return videoTrack ? (
+  return (
     <Container>
-      <VideoTrack track={videoTrack} isLocal />
-      <CallToAction>Welcome! Join a party room using the drawer below!</CallToAction>
+      {videoTrack && <VideoTrack track={videoTrack} isLocal />}
+      <CallToAction>Welcome! Click to join a party room using the drawer below!</CallToAction>
     </Container>
-  ) : null;
+  );
 }

--- a/src/components/MenuBar/RoomInfoButtonAndPopOver/RoomInfoButtonAndPopOver.tsx
+++ b/src/components/MenuBar/RoomInfoButtonAndPopOver/RoomInfoButtonAndPopOver.tsx
@@ -23,14 +23,18 @@ const RoomRulesContent = styled('div')({
 export default function RoomInfoButtonAndPopOver() {
   const currentRoom = useCurrentRoom();
   const roomTitle = currentRoom?.name ? `Rules for the ${currentRoom.name}` : 'Room rules';
-  const roomDescription = currentRoom?.description || 'No description was provided...this is a mystery room.';
+  const roomDescription = currentRoom?.description;
 
   return (
-    <IconContainer>
-      <PopOverWithButton buttonType={BUTTON_TYPE_INFO} popOverId="room-info-popover">
-        <RoomRulesTitle>{roomTitle}</RoomRulesTitle>
-        <RoomRulesContent>{roomDescription}</RoomRulesContent>
-      </PopOverWithButton>
-    </IconContainer>
+    <>
+      {roomDescription && (
+        <IconContainer>
+          <PopOverWithButton buttonType={BUTTON_TYPE_INFO} popOverId="room-info-popover">
+            <RoomRulesTitle>{roomTitle}</RoomRulesTitle>
+            <RoomRulesContent>{roomDescription}</RoomRulesContent>
+          </PopOverWithButton>
+        </IconContainer>
+      )}
+    </>
   );
 }

--- a/src/components/RoomGrid/RoomGrid.tsx
+++ b/src/components/RoomGrid/RoomGrid.tsx
@@ -87,7 +87,7 @@ const Header = (props: HeaderProps) => {
 };
 
 export default function RoomGrid() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(true);
   const { rooms } = useRooms();
   const { users } = useUsers();
   const { connectRoom, disconnectRoom } = useConnectRoom();


### PR DESCRIPTION
## Summary
- Open the room grid by default
- Update messaging to be a little more instructive
- Hide the `i` icon if no room description is present

## Test
- locally

<img width="1440" alt="Screen Shot 2020-04-04 at 9 25 29 PM" src="https://user-images.githubusercontent.com/2453344/78464790-8032db80-76bb-11ea-9f60-230138ff3353.png">
<img width="1440" alt="Screen Shot 2020-04-04 at 9 25 20 PM" src="https://user-images.githubusercontent.com/2453344/78464788-7b6e2780-76bb-11ea-9339-cffe9e9f2c0d.png">
