### PR TITLE
Hide scrollbars on windows

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,6 +51,23 @@ const VideoApp = () => {
   );
 };
 
+// note(carlos): scrollbars on Windows suck and always show up, so this is a hack to hide them
+if (navigator.appVersion.indexOf('Win') !== -1) {
+  const style = document.createElement('style');
+  style.type = 'text/css';
+  style.innerHTML = `
+      div::-webkit-scrollbar {
+        display: none;
+      }
+
+      /* Hide scrollbar for IE and Edge */
+      div {
+        -ms-overflow-style: none;
+      }
+  `;
+  document.getElementsByTagName('head')[0].appendChild(style);
+}
+
 ReactDOM.render(
   <MuiThemeProvider theme={theme}>
     <CssBaseline />


### PR DESCRIPTION
Scrollbars on windows suck and they're always visible. This hides them if the OS is Windows.