### PR TITLE
Refactor websocket auth reconnect

### DIFF
--- a/client/src/components/UserSetup/UserSetup.tsx
+++ b/client/src/components/UserSetup/UserSetup.tsx
@@ -106,7 +106,7 @@ export default function LoginPage() {
     } else {
       if (setUser) {
         setUser(name).then(() => {
-          subscriptionClient.close(true, false);
+          // subscriptionClient.close(true);
           history.replace({ pathname: '/' });
         });
       }
@@ -123,7 +123,7 @@ export default function LoginPage() {
     (info: ReactFacebookLoginInfo) => {
       if (setUser) {
         setUser(info.name || '', info?.picture?.data?.url || '').then(() => {
-          subscriptionClient.close(true, false);
+          // subscriptionClient.close(true);
           history.replace({ pathname: '/' });
         });
       }

--- a/client/src/state/usePasscodeAuth/usePasscodeAuth.ts
+++ b/client/src/state/usePasscodeAuth/usePasscodeAuth.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { User } from '../../state';
 import gql from 'graphql-tag';
-import { useMutation } from '@apollo/react-hooks';
+import { useMutation, useApolloClient } from '@apollo/react-hooks';
 
 const REGISTER = gql`
   mutation Register($passcode: String!, $displayName: String!, $photoURL: String) {
@@ -56,6 +56,8 @@ export default function usePasscodeAuth() {
   const [user, setUser] = useState<User | null>(null);
   const [isAuthReady, setIsAuthReady] = useState(false);
   const [authError, setAuthError] = useState<Error | undefined>(undefined);
+  const graphClient = useApolloClient();
+
   const onRegistered = useCallback(
     data => {
       const newUser = {
@@ -65,6 +67,8 @@ export default function usePasscodeAuth() {
       setUser(newUser);
       window.sessionStorage.setItem('user', JSON.stringify(newUser));
       setIsAuthReady(true);
+      //@ts-ignore
+      graphClient.restartWebsocketConnection();
     },
     [user]
   );


### PR DESCRIPTION
Before, multiple imports of `graph.ts` meant that the subscription client was being initialized twice, causing weirdness. Now, it is only imported in once place and I also added a more robust reconnection function for when use auth is changed, albeit monkey-patched into the Apollo client.